### PR TITLE
OP-858 Entering a claim - no active policy

### DIFF
--- a/src/components/InsureePolicyEligibilitySummary.js
+++ b/src/components/InsureePolicyEligibilitySummary.js
@@ -67,7 +67,7 @@ class InsureePolicyEligibilitySummary extends Component {
     render() {
         const { classes, fetchingPolicies, fetchedPolicies, errorPolicies } = this.props;
         const { policies } = this.state;
-        var activePolicies = !!policies && policies.filter(p => this.activePolicyStatus.includes(p.status));
+        var activePolicies = !!policies && policies.filter(p => this.activePolicyStatus.some(s => s == p.status));
         return (
             <Fragment>
                 <ProgressOrError progress={fetchingPolicies} error={errorPolicies} />


### PR DESCRIPTION
[https://openimis.atlassian.net/browse/OP-858](https://openimis.atlassian.net/browse/OP-858)

Changes:
- Fixed policy status check to allow active policy status config field to be specified both as string and integer.