### PR TITLE
OTC-794: fix displaying product balance in claim

### DIFF
--- a/src/components/InsureePolicyEligibilitySummary.js
+++ b/src/components/InsureePolicyEligibilitySummary.js
@@ -107,7 +107,7 @@ class InsureePolicyEligibilitySummary extends Component {
                                     </Grid>
                                     <Grid item xs={3} className={classes.item}>
                                         <AmountInput
-                                            value={(activePolicy.ceiling || 0) - (activePolicy.ded || 0)}
+                                            value={(activePolicy.ceiling || 0)}
                                             module="policy"
                                             label="policies.balance"
                                             readOnly={true}


### PR DESCRIPTION
https://openimis.atlassian.net/browse/OTC-794

Now it displays value that was already calculated on the backend. Previous approach was just inccorect.