### PR TITLE
OTC-786: Alert dialog change, SelectDialog implementation

### DIFF
--- a/src/components/PolicyForm.js
+++ b/src/components/PolicyForm.js
@@ -217,7 +217,6 @@ class PolicyForm extends Component {
   };
 
   canSave = () => {
-    console.log(this.state.policy);
     if (!this.state.policy.family) return false;
     if (!this.state.policy.product) return false;
     if (!this.state.policy.enrollDate) return false;

--- a/src/components/PolicyForm.js
+++ b/src/components/PolicyForm.js
@@ -1,24 +1,26 @@
 import React, { Component, Fragment } from "react";
 import { connect } from "react-redux";
 import { injectIntl } from "react-intl";
-import { withTheme, withStyles } from "@material-ui/core/styles";
 import moment from "moment";
+
+import { withTheme, withStyles } from "@material-ui/core/styles";
+
 import {
-  historyPush,
-  withModulesManager,
-  withHistory,
   coreAlert,
-  journalize,
-  toISODate,
-  formatMessageWithValues,
-  formatMessage,
-  ProgressOrError,
   Form,
+  formatMessage,
+  formatMessageWithValues,
   Helmet,
+  historyPush,
+  journalize,
+  ProgressOrError,
+  SelectDialog,
+  toISODate,
+  withHistory,
+  withModulesManager,
 } from "@openimis/fe-core";
 import PolicyMasterPanel from "./PolicyMasterPanel";
 import { fetchPolicyFull, fetchPolicyValues, fetchFamily } from "../actions";
-import { policyLabel } from "../utils/utils";
 import {
   RIGHT_POLICY,
   RIGHT_POLICY_EDIT,
@@ -26,6 +28,7 @@ import {
   POLICY_STAGE_RENEW,
   POLICY_STATUS_IDLE,
 } from "../constants";
+import { policyLabel } from "../utils/utils";
 
 const styles = (theme) => ({
   page: theme.page,
@@ -40,6 +43,7 @@ class PolicyForm extends Component {
     policy: {},
     newInsuree: true,
     renew: false,
+    confirmProduct: false,
   };
 
   _newPolicy() {
@@ -77,6 +81,13 @@ class PolicyForm extends Component {
     policy.product = from_policy.product;
     return policy;
   }
+
+  confirmProduct = () => {
+    this.setState((state) => ({
+      ...state,
+      confirmProduct: true,
+    }));
+  };
 
   componentDidMount() {
     if (!!this.props.family_uuid && !this.props.policy_uuid)
@@ -144,24 +155,8 @@ class PolicyForm extends Component {
           policy: { ...state.policy, ...this.props.policyValues.policy },
         }),
         (e) => {
-          if (!_.isEmpty(this.props.policyValues.warnings)) {
-            let messages = this.props.policyValues.warnings;
-            messages.push(
-              formatMessage(
-                this.props.intl,
-                "policy",
-                "policyValues.alert.message"
-              )
-            );
-            this.props.coreAlert(
-              formatMessage(
-                this.props.intl,
-                "policy",
-                "policyValues.alert.title"
-              ),
-              messages
-            );
-          }
+          if (!_.isEmpty(this.props.policyValues.warnings))
+            this.confirmProduct();
         }
       );
     } else if (prevProps.policy_uuid && !this.props.policy_uuid) {
@@ -200,7 +195,29 @@ class PolicyForm extends Component {
     this.setState((state) => ({ policy: { ...state.policy, ...p } }));
   };
 
+  onConfirmProductDialog = () => {
+    this.setState((state) => ({
+      ...state,
+      confirmProduct: false,
+    }));
+  };
+
+  onRejectProductDialog = () => {
+    this.setState((state) => ({
+      ...state,
+      confirmProduct: false,
+      policy: {
+        ...state.policy,
+        product: null,
+        startDate: null,
+        expiryDate: null,
+        value: null,
+      },
+    }));
+  };
+
   canSave = () => {
+    console.log(this.state.policy);
     if (!this.state.policy.family) return false;
     if (!this.state.policy.product) return false;
     if (!this.state.policy.enrollDate) return false;
@@ -247,6 +264,16 @@ class PolicyForm extends Component {
             "Policy.title",
             { label: policyLabel(this.props.modulesManager, this.state.policy) }
           )}
+        />
+        <SelectDialog
+          confirmState={this.state.confirmProduct}
+          onConfirm={this.onConfirmProductDialog}
+          onClose={this.onRejectProductDialog}
+          module="policy"
+          confirmTitle="policyValues.alert.title"
+          confirmMessage="policyValues.alert.message"
+          confirmationButton="dialogActions.continue"
+          rejectionButton="dialogActions.goBack"
         />
         <ProgressOrError progress={fetchingPolicy} error={errorPolicy} />
         {((!!fetchedPolicy && !!policy && policy.uuid === policy_uuid) ||

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -117,5 +117,7 @@
   "policy.deletePolicyDialog.title": "Delete policy?",
   "policy.deletePolicyDialog.message": "Are you sure you want to delete policy {label}? Related contributions will be deleted (but not payments).",
   "policy.policyValues.alert.title": "Policy Value Warning:",
-  "policy.policyValues.alert.message": "However, policy can still be created."
+  "policy.policyValues.alert.message": "The family has more Insurees than the maximum number of members allowed in the selected product. However, the policy can still be created. Do you want to continue?",
+  "policy.dialogActions.continue": "Continue",
+  "policy.dialogActions.goBack": "Go back"
 }


### PR DESCRIPTION
[CORE PR](https://github.com/openimis/openimis-fe-core_js/pull/96) REQUIRED

[OTC-786](https://openimis.atlassian.net/browse/OTC-786)

In scope of this ticket:
- I changed _AlertDialog_ into _SelectDialog_, which informs the users about the exceeded number of insurees in given family to decided whether they want to continue/go back and change a product.
- If user decides to continue, the pop up disappears and saving is possible.
- If user decides to go back, the form is cleared and there is a possibility to pick other product.
- I created new translations keys and added them to the Lokalise. The existing one is also updated.

[OTC-786]: https://openimis.atlassian.net/browse/OTC-786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ