### PR TITLE
OTC-757: Clearing pagination state if entered the PoliciesPage

### DIFF
--- a/src/pages/PoliciesPage.js
+++ b/src/pages/PoliciesPage.js
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import { injectIntl } from "react-intl";
 import { withTheme, withStyles } from "@material-ui/core/styles";
@@ -6,6 +7,7 @@ import {
   historyPush,
   withModulesManager,
   withHistory,
+  clearCurrentPaginationPage,
 } from "@openimis/fe-core";
 import PolicySearcher from "../components/PolicySearcher";
 
@@ -22,6 +24,12 @@ class PoliciesPage extends Component {
       [p.uuid],
       newTab
     );
+  };
+
+  componentDidMount = () => {
+    const moduleName = "policy";
+    const { module } = this.props;
+    if (module !== moduleName) this.props.clearCurrentPaginationPage();
   };
 
   render() {
@@ -42,12 +50,15 @@ const mapStateToProps = (state) => ({
     !!state.core && !!state.core.user && !!state.core.user.i_user
       ? state.core.user.i_user.rights
       : [],
+  module: state.core?.savedPagination?.module,
 });
+
+const mapDispatchToProps = (dispatch) => bindActionCreators({ clearCurrentPaginationPage }, dispatch);
 
 export default injectIntl(
   withModulesManager(
     withHistory(
-      connect(mapStateToProps)(withTheme(withStyles(styles)(PoliciesPage)))
+      connect(mapStateToProps, mapDispatchToProps)(withTheme(withStyles(styles)(PoliciesPage)))
     )
   )
 );

--- a/src/pages/PoliciesPage.js
+++ b/src/pages/PoliciesPage.js
@@ -1,35 +1,53 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
-import { injectIntl } from 'react-intl';
+import { injectIntl } from "react-intl";
 import { withTheme, withStyles } from "@material-ui/core/styles";
-import { historyPush, withModulesManager, withHistory } from "@openimis/fe-core";
+import {
+  historyPush,
+  withModulesManager,
+  withHistory,
+} from "@openimis/fe-core";
 import PolicySearcher from "../components/PolicySearcher";
 
-const styles = theme => ({
-    page: theme.page,
+const styles = (theme) => ({
+  page: theme.page,
 });
 
 class PoliciesPage extends Component {
+  onDoubleClick = (p, newTab = false) => {
+    historyPush(
+      this.props.modulesManager,
+      this.props.history,
+      "policy.route.policy",
+      [p.uuid],
+      newTab
+    );
+  };
 
-    onDoubleClick = (p, newTab = false) => {
-        historyPush(this.props.modulesManager, this.props.history, "policy.route.policy", [p.uuid], newTab)
-    }
-
-    render() {
-        const { classes } = this.props;
-        return (
-            <div className={classes.page}>
-                <PolicySearcher
-                    cacheFiltersKey="policyPoliciesPageFiltersCache"
-                    onDoubleClick={this.onDoubleClick}
-                />
-            </div >
-        )
-    }
+  render() {
+    const { classes } = this.props;
+    return (
+      <div className={classes.page}>
+        <PolicySearcher
+          cacheFiltersKey="policyPoliciesPageFiltersCache"
+          onDoubleClick={this.onDoubleClick}
+        />
+      </div>
+    );
+  }
 }
 
-const mapStateToProps = state => ({
-    rights: !!state.core && !!state.core.user && !!state.core.user.i_user ? state.core.user.i_user.rights : [],
-})
+const mapStateToProps = (state) => ({
+  rights:
+    !!state.core && !!state.core.user && !!state.core.user.i_user
+      ? state.core.user.i_user.rights
+      : [],
+});
 
-export default injectIntl(withModulesManager(withHistory(connect(mapStateToProps)(withTheme(withStyles(styles)(PoliciesPage))))));
+export default injectIntl(
+  withModulesManager(
+    withHistory(
+      connect(mapStateToProps)(withTheme(withStyles(styles)(PoliciesPage)))
+    )
+  )
+);


### PR DESCRIPTION
[OTC-757](https://openimis.atlassian.net/browse/OTC-757)

Changes:

- Code refactor in PoliciesPage.
- Clearing pagination state if entered the PoliciesPage.
- Implementation of the logic responsible for going back from edit form and keeping the same page which was before.

[OTC-757]: https://openimis.atlassian.net/browse/OTC-757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ