### PR TITLE
OTC-1037: adjusting productPicker and PolicyOfficerPicker labels/plac…

### DIFF
--- a/src/components/PolicyMasterPanel.js
+++ b/src/components/PolicyMasterPanel.js
@@ -285,14 +285,20 @@ class PolicyMasterPanel extends FormPanel {
                   module="policy"
                   readOnly={!!edited_id || readOnly}
                   withNull={true}
+                  label={formatMessage(intl, "product", "Product")}
+                  withLabel={true}
                   nullLabel={formatMessage(intl, "product", "Product.none")}
+                  withPlaceholder={true}
+                  placeholder={formatMessage(
+                    intl,
+                    "product",
+                    "ProductPicker.placeholder"
+                  )}
                   onChange={this._onProductChange}
                   required={true}
                   locationId={
                     !!edited.family
-                      ? decodeId(
-                          edited.family?.location?.parent?.parent?.id
-                        )
+                      ? decodeId(edited.family?.location?.parent?.parent?.id)
                       : 0
                   }
                 />
@@ -303,6 +309,14 @@ class PolicyMasterPanel extends FormPanel {
                   value={!!edited && edited.officer}
                   module="policy"
                   readOnly={readOnly}
+                  withPlaceholder={true}
+                  withLabel={true}
+                  label={formatMessage(intl, "policy", "PolicyOfficerPicker.label")}
+                  placeholder={formatMessage(
+                    intl,
+                    "policy",
+                    "PolicyOfficerPicker.placeholder"
+                  )}
                   withNull={true}
                   nullLabel={formatMessage(
                     intl,

--- a/src/pickers/PolicyOfficerPicker.js
+++ b/src/pickers/PolicyOfficerPicker.js
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { TextField } from "@material-ui/core";
 import {
   useTranslations,
   Autocomplete,
@@ -18,6 +19,7 @@ const PolicyOfficerPicker = (props) => {
     filterSelectedOptions,
     placeholder,
     extraFragment,
+    nullLabel,
     multiple,
     filters,
     villageId,
@@ -58,14 +60,7 @@ const PolicyOfficerPicker = (props) => {
   return (
     <Autocomplete
       multiple={multiple}
-      required={required}
-      placeholder={
-        placeholder ?? formatMessage("PolicyOfficerPicker.placeholder")
-      }
-      label={label ?? formatMessage("PolicyOfficerPicker.label")}
       error={error}
-      withLabel={withLabel}
-      withPlaceholder={withPlaceholder}
       readOnly={readOnly}
       options={data?.policyOfficers?.edges.map((edge) => edge.node) ?? []}
       isLoading={isLoading}
@@ -84,6 +79,16 @@ const PolicyOfficerPicker = (props) => {
       filterOptions={filterOptions}
       filterSelectedOptions={filterSelectedOptions}
       onInputChange={setSearchString}
+      renderInput={(inputProps) => (
+        <TextField
+          {...inputProps}
+          required={required}
+          label={withLabel && (label || nullLabel)}
+          placeholder={
+            withPlaceholder && (placeholder || formatMessage("Search..."))
+          }
+        />
+      )}
     />
   );
 };


### PR DESCRIPTION
…eholders

**[CORE PR](https://github.com/openimis/openimis-fe-core_js/pull/110) AND [PRODUCT PR](https://github.com/openimis/openimis-fe-product_js/pull/43) REQUIRED**

[OTC-1037](https://openimis.atlassian.net/browse/OTC-1037)

Changes:
- I added the _renderInput_ prop to the PolicyOfficerPicker to fix the issue with crashing label and placeholder.
- I adjusted props (provided to the _ProductPicker_ and _PolicyOfficerPicker_) to implemented logic.


[OTC-1037]: https://openimis.atlassian.net/browse/OTC-1037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ