### PR TITLE
OP-1329: when fetching data with policy uuid allow historical policies

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -167,7 +167,7 @@ export function fetchPolicyFull(mm, policy_uuid) {
   ];
   const payload = formatPageQuery(
     "policies",
-    [`uuid: "${policy_uuid}"`],
+    [`uuid: "${policy_uuid}"`, 'showHistory: true'],
     projections
   );
   return graphql(payload, "POLICY_POLICY");


### PR DESCRIPTION
https://openimis.atlassian.net/browse/OP-1329

This PR sets showHistorical flag to always true when fetching a particular policy.