### PR TITLE
OTC-1005: zero is displayed when paid value or balance is NaN

### DIFF
--- a/src/components/PolicyValuesPanel.js
+++ b/src/components/PolicyValuesPanel.js
@@ -66,7 +66,8 @@ class PolicyValuesPanel extends Component {
                 <AmountInput
                   module="policy"
                   label="Policy.sumPremiums"
-                  value={edited.sumPremiums}
+                  value={edited.sumPremiums || 0}
+                  displayZero={true}
                   readOnly={readOnly}
                 />
               </Grid>
@@ -74,7 +75,8 @@ class PolicyValuesPanel extends Component {
                 <AmountInput
                   module="policy"
                   label="Policy.balance"
-                  value={edited.balance}
+                  value={edited.balance || 0}
+                  displayZero={true}
                   readOnly={readOnly}
                 />
               </Grid>


### PR DESCRIPTION
Ticket:
https://openimis.atlassian.net/browse/OTC-1005

Changes:
- zero is displayed instead of empty string for contribution paid and balance values