### PR TITLE
OP-1400: PolicyOfficerPicker default label/placeholder

### DIFF
--- a/src/pickers/PolicyOfficerPicker.js
+++ b/src/pickers/PolicyOfficerPicker.js
@@ -1,5 +1,7 @@
 import React, { useState } from "react";
+
 import { TextField } from "@material-ui/core";
+
 import {
   useTranslations,
   Autocomplete,
@@ -11,8 +13,8 @@ const PolicyOfficerPicker = (props) => {
     onChange,
     readOnly,
     required,
-    withLabel = true,
-    withPlaceholder,
+    withLabel = false,
+    withPlaceholder = false,
     value,
     label,
     filterOptions,
@@ -83,9 +85,13 @@ const PolicyOfficerPicker = (props) => {
         <TextField
           {...inputProps}
           required={required}
-          label={withLabel && (label || nullLabel)}
+          label={
+            (withLabel && (label || nullLabel)) ||
+            formatMessage("PolicyOfficerPicker.label")
+          }
           placeholder={
-            withPlaceholder && (placeholder || formatMessage("Search..."))
+            (withPlaceholder && placeholder) ||
+            formatMessage("PolicyOfficerPicker.placeholder")
           }
         />
       )}


### PR DESCRIPTION
[OP-1400](https://openimis.atlassian.net/browse/OP-1400)

Changes:
- If PolicyOfficerPicker label/placeholder is not defined, display default setup.

[OP-1400]: https://openimis.atlassian.net/browse/OP-1400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ