### PR TITLE
OP-1536: pass required prop to the autocomplete component

### DIFF
--- a/src/pickers/PolicyOfficerPicker.js
+++ b/src/pickers/PolicyOfficerPicker.js
@@ -62,6 +62,7 @@ const PolicyOfficerPicker = (props) => {
   return (
     <Autocomplete
       multiple={multiple}
+      required={required}
       error={error}
       readOnly={readOnly}
       options={data?.policyOfficers?.edges.map((edge) => edge.node) ?? []}


### PR DESCRIPTION
[OP-1536](https://openimis.atlassian.net/browse/OP-1536)

[RELATED CORE PR](https://github.com/openimis/openimis-fe-core_js/pull/153)

Changes:
- Pass required prop to the Autocomplete component.

[OP-1536]: https://openimis.atlassian.net/browse/OP-1536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ