### PR TITLE
ONI-19: show 2 latest policies in enquire

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,4 +56,5 @@ None
 * `state.insuree`, loading insuree policies (,eligibility,...)
 
 ## Configurations Options
-None
+- `familyOrInsureePoliciesSummary.orderByExpiryDate`: Allows to set whether you want to sort policies by expiry date in ascending or descending order. Default: __"expiryDate"__ which means ascending order.
+- `familyOrInsureePoliciesSummary.onlyActiveOrLastExpired`: Enables to choose whether you want to display only active and the last expired policies, or all. Default: __true__. 

--- a/src/components/FamilyOrInsureePoliciesSummary.js
+++ b/src/components/FamilyOrInsureePoliciesSummary.js
@@ -3,9 +3,11 @@ import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import { injectIntl } from "react-intl";
 import clsx from "clsx";
+
 import { withTheme, withStyles } from "@material-ui/core/styles";
 import { Divider, Grid, Paper, Typography, FormControlLabel, Checkbox, IconButton } from "@material-ui/core";
 import { Add as AddIcon, Autorenew as RenewIcon, Delete as DeleteIcon, Pause as SuspendIcon } from "@material-ui/icons";
+
 import {
   Table,
   PagedDataHandler,
@@ -22,8 +24,8 @@ import {
   journalize,
 } from "@openimis/fe-core";
 import { fetchFamilyOrInsureePolicies, selectPolicy, deletePolicy, suspendPolicy } from "../actions";
-import { policyLabel, canDeletePolicy, canSuspendPolicy, canRenewPolicy } from "../utils/utils";
 import { RIGHT_POLICY_ADD } from "../constants";
+import { policyLabel, canDeletePolicy, canSuspendPolicy, canRenewPolicy } from "../utils/utils";
 
 const styles = (theme) => ({
   paper: {
@@ -47,6 +49,17 @@ const styles = (theme) => ({
 });
 
 class FamilyOrInsureePoliciesSummary extends PagedDataHandler {
+  state = {
+    page: 0,
+    pageSize: this.props.modulesManager.getConf(
+      "fe-policy",
+      "familyOrInsureePoliciesSummary.defaultPageSize",
+      5
+    ),
+    afterCursor: null,
+    beforeCursor: null,
+  };
+
   constructor(props) {
     super(props);
     this.rowsPerPageOptions = props.modulesManager.getConf(
@@ -59,15 +72,29 @@ class FamilyOrInsureePoliciesSummary extends PagedDataHandler {
       "familyOrInsureePoliciesSummary.defaultPageSize",
       5
     );
-    this.showBalance = props.modulesManager.getConf("fe-policy", "familyOrInsureePoliciesSummary.showBalance", false);
+    this.showBalance = props.modulesManager.getConf(
+      "fe-policy",
+      "familyOrInsureePoliciesSummary.showBalance",
+      false
+    );
+    this.onlyActiveOrLastExpired = props.modulesManager.getConf(
+      "fe-policy",
+      "familyOrInsureePoliciesSummary.onlyActiveOrLastExpired",
+      true
+    );
+    this.orderByExpiryDate = props.modulesManager.getConf(
+      "fe-policy",
+      "familyOrInsureePoliciesSummary.orderByExpiryDate",
+      "expiryDate"
+    );
   }
 
   componentDidMount() {
     this.setState(
       {
         confirmedAction: null,
-        onlyActiveOrLastExpired: true,
-        orderBy: "expiryDate",
+        onlyActiveOrLastExpired: this.onlyActiveOrLastExpired,
+        orderBy: this.orderByExpiryDate,
       },
       (e) => this.query()
     );


### PR DESCRIPTION
[ONI-19](https://openimis.atlassian.net/browse/ONI-19)

Changes:
- Display 2 latest policies in insuree enquire dialog.

![image](https://github.com/openimis/openimis-fe-policy_js/assets/109145288/bca5c9c6-7454-4b43-a219-463a902cabc4)


[ONI-19]: https://openimis.atlassian.net/browse/ONI-19?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ