### PR TITLE
OP-1645: pass enrolldate to product picker

### DIFF
--- a/src/components/PolicyMasterPanel.js
+++ b/src/components/PolicyMasterPanel.js
@@ -318,6 +318,7 @@ class PolicyMasterPanel extends FormPanel {
                       ? decodeId(edited.family?.location?.parent?.parent?.id)
                       : 0
                   }
+                  enrollmentDate={edited?.enrollDate ?? null}
                 />
               </Grid>
               <Grid item xs={3} className={classes.item}>


### PR DESCRIPTION
[OP-1645](https://openimis.atlassian.net/browse/OP-1645)

[REQUIRED PR](https://github.com/openimis/openimis-fe-product_js/pull/72)

Changes:
- Pass information about enrollment date to product picker.

[OP-1645]: https://openimis.atlassian.net/browse/OP-1645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ