### PR TITLE
OP-1696: add policy value to the columns

### DIFF
--- a/src/components/FamilyOrInsureePoliciesSummary.js
+++ b/src/components/FamilyOrInsureePoliciesSummary.js
@@ -22,6 +22,7 @@ import {
   withHistory,
   coreConfirm,
   journalize,
+  AmountInput,
 } from "@openimis/fe-core";
 import { fetchFamilyOrInsureePolicies, selectPolicy, deletePolicy, suspendPolicy } from "../actions";
 import { RIGHT_POLICY_ADD } from "../constants";
@@ -220,6 +221,7 @@ class FamilyOrInsureePoliciesSummary extends PagedDataHandler {
       "policies.enrolmentDate",
       "policies.expiryDate",
       "policies.status",
+      "policies.policyValue",
       "policies.deduction",
       "policies.hospitalDeduction",
       "policies.nonHospitalDeduction",
@@ -250,6 +252,7 @@ class FamilyOrInsureePoliciesSummary extends PagedDataHandler {
       this.sorter("enrolmentDate"),
       this.sorter("expiryDate"),
       this.sorter("status"),
+      this.sorter("policyValue"),
       this.sorter("deduction"),
       this.sorter("hospitalDeduction"),
       this.sorter("nonHospitalDeduction"),
@@ -275,6 +278,7 @@ class FamilyOrInsureePoliciesSummary extends PagedDataHandler {
       (i) => formatDateFromISO(this.props.modulesManager, this.props.intl, i.enrollDate),
       (i) => formatDateFromISO(this.props.modulesManager, this.props.intl, i.expiryDate),
       (i) => formatMessage(this.props.intl, "policy", `policies.status.${i.status}`),
+      (i) => <AmountInput value={i.policyValue} readOnly />,
       (i) => i.ded,
       (i) => i.dedInPatient,
       (i) => i.dedOutPatient,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -10,6 +10,7 @@
   "policy.policies.enrolmentDate": "Enrolment Date",
   "policy.policies.officer": "Enrollment Officer",
   "policy.policies.status": "Status",
+  "policy.policies.policyValue": "Policy Value",
   "policy.policies.status.0": "",
   "policy.policies.status.1": "Idle",
   "policy.policies.status.2": "Active",


### PR DESCRIPTION
[OP-1696](https://openimis.atlassian.net/browse/OP-1696)

Changes:
- Add information about policy value to the family details page.

![image](https://github.com/openimis/openimis-fe-policy_js/assets/109145288/f92ad143-3a21-4127-84a5-fad96419238d)


[OP-1696]: https://openimis.atlassian.net/browse/OP-1696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ