### PR TITLE
OP-1725: remove null/empty option from dropdown

### DIFF
--- a/src/components/PolicyMasterPanel.js
+++ b/src/components/PolicyMasterPanel.js
@@ -358,8 +358,7 @@ class PolicyMasterPanel extends FormPanel {
                   value={!!edited && edited.status}
                   module="policy"
                   readOnly={true}
-                  withNull={true}
-                  nullLabel="PolicyStatus.none"
+                  withNull={false}
                   onChange={(v) => this.updateAttribute("status", v)}
                 />
               </Grid>


### PR DESCRIPTION
[OP-1725](https://openimis.atlassian.net/browse/OP-1725)

Changes:

- Remove the 'none/null' option from the dropdowns menu in the form.

[OP-1725]: https://openimis.atlassian.net/browse/OP-1725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ