### PR TITLE
ONI-29: add checkbox to pay policy in one installment, contrib preview

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -205,6 +205,7 @@ function formatPolicyGQL(mm, policy) {
       ? `uuid: "${policy.uuid}"`
       : ""
   }
+  ${policy.isPaid ? `isPaid: ${policy.isPaid}` : ""}
   enrollDate: "${policy.enrollDate}"
   startDate: "${policy.startDate}"
   expiryDate: "${policy.expiryDate}"

--- a/src/actions.js
+++ b/src/actions.js
@@ -206,7 +206,7 @@ function formatPolicyGQL(mm, policy) {
       : ""
   }
   ${policy.isPaid ? `isPaid: ${policy.isPaid}` : ""}
-  ${policy.receipt ? `receipt: ${policy.receipt}` : ""}
+  ${policy.receipt ? `receipt: "${policy.receipt}"` : ""}
   enrollDate: "${policy.enrollDate}"
   startDate: "${policy.startDate}"
   expiryDate: "${policy.expiryDate}"

--- a/src/actions.js
+++ b/src/actions.js
@@ -206,6 +206,7 @@ function formatPolicyGQL(mm, policy) {
       : ""
   }
   ${policy.isPaid ? `isPaid: ${policy.isPaid}` : ""}
+  ${policy.receipt ? `receipt: ${policy.receipt}` : ""}
   enrollDate: "${policy.enrollDate}"
   startDate: "${policy.startDate}"
   expiryDate: "${policy.expiryDate}"

--- a/src/actions.js
+++ b/src/actions.js
@@ -5,9 +5,9 @@ import {
   formatPageQueryWithCount,
   formatMutation,
   toISODate,
+  decodeId,
 } from "@openimis/fe-core";
 import _ from "lodash";
-import { decodeId } from "@openimis/fe-core";
 
 const FAMILY_HEAD_PROJECTION =
   "headInsuree{id,uuid,chfId,lastName,otherNames,email,phone,dob,gender{code}}";

--- a/src/components/PolicyForm.js
+++ b/src/components/PolicyForm.js
@@ -52,6 +52,7 @@ class PolicyForm extends Component {
     policy.stage = POLICY_STAGE_NEW;
     policy.enrollDate = toISODate(moment().toDate());
     policy.jsonExt = {};
+    policy.isPaid = false;
     if (
       !!this.props.family &&
       this.props.family.uuid === this.props.family_uuid

--- a/src/components/PolicyMasterPanel.js
+++ b/src/components/PolicyMasterPanel.js
@@ -9,6 +9,8 @@ import {
   Typography,
   Divider,
   IconButton,
+  FormControlLabel,
+  Checkbox,
 } from "@material-ui/core";
 import {
   Autorenew as RenewIcon,
@@ -29,6 +31,7 @@ import {
   PublishedComponent,
   ProgressOrError,
   decodeId,
+  AmountInput,
 } from "@openimis/fe-core";
 import {
   policyLabel,
@@ -48,14 +51,19 @@ const POLICY_POLICY_CONTRIBUTION_KEY = "policy.Policy";
 const POLICY_POLICY_PANELS_CONTRIBUTION_KEY = "policy.Policy.panels";
 
 class PolicyMasterPanel extends FormPanel {
-  constructor(props){
+  constructor(props) {
     super(props);
-  
+
     this.minimumPolicyEffectiveDate = this.props.modulesManager.getConf(
       "fe-policy",
       "minimumPolicyEffectiveDate",
       0
     );
+    this.defaultPaymentType = this.props.modulesManager.getConf(
+      "fe-policy",
+      "defaultPaymentTypeOfContribution",
+      "C"
+    )
   }
 
   componentDidUpdate(prevProps, prevState, snapshot) {
@@ -362,6 +370,62 @@ class PolicyMasterPanel extends FormPanel {
                   onChange={(v) => this.updateAttribute("status", v)}
                 />
               </Grid>
+              <Grid xs={12}>
+                <Grid item xs={3} className={classes.item}>
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        color="primary"
+                        checked={edited?.isPaid}
+                        onChange={(e) =>
+                          this.updateAttribute("isPaid", e.target.checked)
+                        }
+                      />
+                    }
+                    disabled={readOnly}
+                    label={formatMessage(
+                      intl,
+                      "policy",
+                      "Policy.payInOneInstallment"
+                    )}
+                  />
+                </Grid>
+              </Grid>
+              {edited?.isPaid && (
+                <>
+                  <Grid item xs={12} className={classes.item}>
+                    <Typography variant="subtitle1">
+                      <FormattedMessage module="policy" id="Policy.contribDetails" />
+                    </Typography>
+                  </Grid>
+                  <Grid item xs={3} className={classes.item}>
+                    <PublishedComponent
+                      pubRef="core.DatePicker"
+                      module="contribution"
+                      value={edited?.enrollDate}
+                      readOnly
+                      label="contribution.payDate"
+                    />
+                  </Grid>
+                  <Grid item xs={3} className={classes.item}>
+                    <AmountInput
+                      module="contribution"
+                      label="contribution.amount"
+                      readOnly
+                      value={edited?.value || 0}
+                      displayZero={true}
+                    />
+                  </Grid>
+                  <Grid item xs={3} className={classes.item}>
+                    <PublishedComponent
+                      pubRef='contribution.PremiumPaymentTypePicker'
+                      withNull={false}
+                      readOnly
+                      value={this.defaultPaymentType}
+                    />
+                  </Grid>
+                </>
+              )}
               <Contributions
                 {...this.props}
                 updateAttribute={this.updateAttribute}

--- a/src/components/PolicyMasterPanel.js
+++ b/src/components/PolicyMasterPanel.js
@@ -32,6 +32,7 @@ import {
   ProgressOrError,
   decodeId,
   AmountInput,
+  TextInput,
 } from "@openimis/fe-core";
 import {
   policyLabel,
@@ -63,7 +64,7 @@ class PolicyMasterPanel extends FormPanel {
       "fe-policy",
       "defaultPaymentTypeOfContribution",
       "C"
-    )
+    );
   }
 
   componentDidUpdate(prevProps, prevState, snapshot) {
@@ -370,33 +371,57 @@ class PolicyMasterPanel extends FormPanel {
                   onChange={(v) => this.updateAttribute("status", v)}
                 />
               </Grid>
-              <Grid xs={12}>
-                <Grid item xs={3} className={classes.item}>
-                  <FormControlLabel
-                    control={
-                      <Checkbox
-                        color="primary"
-                        checked={edited?.isPaid}
-                        onChange={(e) =>
-                          this.updateAttribute("isPaid", e.target.checked)
-                        }
-                      />
-                    }
-                    disabled={readOnly}
-                    label={formatMessage(
-                      intl,
-                      "policy",
-                      "Policy.payInOneInstallment"
-                    )}
-                  />
+              {!edited_id && (
+                <Grid xs={12}>
+                  <Grid item xs={3} className={classes.item}>
+                    <FormControlLabel
+                      control={
+                        <Checkbox
+                          color="primary"
+                          checked={edited?.isPaid}
+                          onChange={(e) =>
+                            this.updateAttribute("isPaid", e.target.checked)
+                          }
+                        />
+                      }
+                      disabled={readOnly}
+                      label={formatMessage(
+                        intl,
+                        "policy",
+                        "Policy.payInOneInstallment"
+                      )}
+                    />
+                  </Grid>
                 </Grid>
-              </Grid>
+              )}
               {edited?.isPaid && (
                 <>
                   <Grid item xs={12} className={classes.item}>
                     <Typography variant="subtitle1">
-                      <FormattedMessage module="policy" id="Policy.contribDetails" />
+                      <FormattedMessage
+                        module="policy"
+                        id="Policy.contribDetails"
+                      />
                     </Typography>
+                    <i>
+                      <Typography variant="body2">
+                        <FormattedMessage
+                          module="policy"
+                          id="Policy.contribDetails.warning"
+                        />
+                      </Typography>
+                    </i>
+                  </Grid>
+                  <Grid item xs={3} className={classes.item}>
+                    <TextInput
+                      module="contribution"
+                      label="contribution.receipt"
+                      readOnly={readOnly}
+                      value={edited?.receipt}
+                      onChange={(receipt) =>
+                        this.updateAttribute("receipt", receipt)
+                      }
+                    />
                   </Grid>
                   <Grid item xs={3} className={classes.item}>
                     <PublishedComponent
@@ -418,7 +443,7 @@ class PolicyMasterPanel extends FormPanel {
                   </Grid>
                   <Grid item xs={3} className={classes.item}>
                     <PublishedComponent
-                      pubRef='contribution.PremiumPaymentTypePicker'
+                      pubRef="contribution.PremiumPaymentTypePicker"
                       withNull={false}
                       readOnly
                       value={this.defaultPaymentType}

--- a/src/components/PolicyValuesPanel.js
+++ b/src/components/PolicyValuesPanel.js
@@ -47,7 +47,7 @@ class PolicyValuesPanel extends Component {
           </Grid>
           <Divider />
           <Grid container className={classes.item}>
-            <Grid container alignItems="center" justify="center">
+            <Grid container alignItems="center" justify="start">
               <Grid item xs={3} className={classes.item}>
                 <ProgressOrError
                   progress={fetchingPolicyValues}
@@ -83,7 +83,7 @@ class PolicyValuesPanel extends Component {
             </Grid>
             <Grid container alignItems="center">
               <Grid item xs={12}>
-                <Divider />
+                <Divider style={{ margin: "10px 0" }} />
               </Grid>
               <Grid item xs={3} />
               <Grid item xs={3} className={classes.itemcenter}>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -113,6 +113,7 @@
   "policy.Policy.expiryDate": "Expiry Date",
   "policy.Policy.payInOneInstallment": "Pay in one installment",
   "policy.Policy.contribDetails": "Contribution Details",
+  "policy.Policy.contribDetails.warning": "WARNING: Leaving the receipt field blank triggers auto-generation. Ensure uniqueness.",
   "policy.CreatePolicy.mutationLabel": "Create Policy {policy}",
   "policy.UpdatePolicy.mutationLabel": "Update Policy {policy}",
   "policy.RenewPolicy.mutationLabel": "Renew Policy {policy}",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -111,6 +111,8 @@
   "policy.Policy.effectiveDate": "Effective Date",
   "policy.Policy.startDate": "Start Date",
   "policy.Policy.expiryDate": "Expiry Date",
+  "policy.Policy.payInOneInstallment": "Pay in one installment",
+  "policy.Policy.contribDetails": "Contribution Details",
   "policy.CreatePolicy.mutationLabel": "Create Policy {policy}",
   "policy.UpdatePolicy.mutationLabel": "Update Policy {policy}",
   "policy.RenewPolicy.mutationLabel": "Renew Policy {policy}",


### PR DESCRIPTION
[ONI-29](https://openimis.atlassian.net/browse/ONI-29)

Changes:
- Add possibility to pay in one installment directly from the policy page.
- Add preview of contribution.
- Pass _isPaid_ parameter accordingly.
![image](https://github.com/openimis/openimis-fe-policy_js/assets/109145288/734c4b6e-1118-4c82-9ccb-61ab9ecfb48a)

EDIT:
![image](https://github.com/openimis/openimis-fe-policy_js/assets/109145288/5789ed44-c1b4-45dd-91bc-1efe46ac271f)



[ONI-29]: https://openimis.atlassian.net/browse/ONI-29?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ