### PR TITLE
OP-1790: hide validity to/from when not historical data

### DIFF
--- a/src/components/PolicySearcher.js
+++ b/src/components/PolicySearcher.js
@@ -118,7 +118,7 @@ class PolicySearcher extends Component {
     canRenew = (policy) => !this.props.renew && canRenewPolicy(this.props.rights, policy)
 
     headers = (filters) => {
-        var h = [
+        const h = [
             "policy.policySummaries.enrollDate",
             "policy.policySummaries.name",
             "policy.policySummaries.effectiveDate",
@@ -130,8 +130,12 @@ class PolicySearcher extends Component {
             "policy.policySummaries.status",
             "policy.policySummaries.value",
             "policy.policySummaries.balance",
-            "policy.policySummaries.validityFrom",
-            "policy.policySummaries.validityTo",
+            filters?.showHistory?.value
+            ? "policy.policySummaries.validityFrom"
+            : null,
+          filters?.showHistory?.value
+            ? "policy.policySummaries.validityTo"
+            : null,
             "policy.policySummaries.openFamily",
             "policy.policySummaries.openNewTab",
             "policy.policySummaries.renew",
@@ -142,7 +146,7 @@ class PolicySearcher extends Component {
     }
 
     sorts = (filters) => {
-        var results = [
+        const results = [
             ['enrollDate', false],
             [this.props.modulesManager.getRef("insuree.FamilyPicker.sort"), true],
             ['effectiveDate', false],
@@ -154,14 +158,14 @@ class PolicySearcher extends Component {
             ['status', true],
             ['value', false],
             null,
-            ['validityFrom', false],
-            ['validityTo', false],
+            filters?.showHistory?.value ? ["validityFrom", false] : null,
+            filters?.showHistory?.value ? ["validityTo", false] : null,
         ];
         return results;
     }
 
     itemFormatters = (filters) => {
-        var formatters = [
+        const formatters = [
             policy => formatDateFromISO(this.props.modulesManager, this.props.intl, policy.enrollDate),
             policy => <PublishedComponent pubRef="insuree.FamilyPicker" value={policy.family} readOnly={true} withLabel={false} />,
             policy => formatDateFromISO(this.props.modulesManager, this.props.intl, policy.effectiveDate),
@@ -173,14 +177,22 @@ class PolicySearcher extends Component {
             policy => <PublishedComponent pubRef="policy.PolicyStatusPicker" value={policy.status} readOnly={true} withLabel={false} />,
             policy => <AmountInput value={policy.value} readOnly={true} />,
             policy => <AmountInput value={policyBalance(policy)} readOnly={true} />,
-            policy => formatDateFromISO(
-                this.props.modulesManager,
-                this.props.intl,
-                policy.validityFrom),
-            policy => formatDateFromISO(
-                this.props.modulesManager,
-                this.props.intl,
-                policy.validityTo),
+            filters?.showHistory?.value
+              ? (policy) =>
+                  formatDateFromISO(
+                    this.props.modulesManager,
+                    this.props.intl,
+                    policy.validityFrom
+                  )
+              : null,
+            filters?.showHistory?.value
+              ? (policy) =>
+                  formatDateFromISO(
+                    this.props.modulesManager,
+                    this.props.intl,
+                    policy.validityTo
+                  )
+              : null,
             policy => {
                 if (!policy.family) return null
                 return (


### PR DESCRIPTION
[OP-1790](https://openimis.atlassian.net/browse/OP-1790)

[REQUIRED PR](https://github.com/openimis/openimis-fe-core_js/pull/197)

Changes:
- Show or hide "Validity From" and "Validity To" columns based on the _showHistory_ filter.



[OP-1790]: https://openimis.atlassian.net/browse/OP-1790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ