### PR TITLE
OP-1823: add payer dropdown when paying in one installment

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -207,6 +207,7 @@ function formatPolicyGQL(mm, policy) {
   }
   ${policy.isPaid ? `isPaid: ${policy.isPaid}` : ""}
   ${policy.receipt ? `receipt: "${policy.receipt}"` : ""}
+  ${policy.payer ? `payerUuid: "${policy.payer.uuid}"` : ""}
   enrollDate: "${policy.enrollDate}"
   startDate: "${policy.startDate}"
   expiryDate: "${policy.expiryDate}"

--- a/src/components/PolicyForm.js
+++ b/src/components/PolicyForm.js
@@ -213,7 +213,6 @@ class PolicyForm extends Component {
   };
 
   canSave = () => {
-    if (this.state.policy.isPaid && !this.state.policy.payer) return false;
     if (!this.state.policy.family) return false;
     if (!this.state.policy.product) return false;
     if (!this.state.policy.enrollDate) return false;

--- a/src/components/PolicyForm.js
+++ b/src/components/PolicyForm.js
@@ -213,6 +213,7 @@ class PolicyForm extends Component {
   };
 
   canSave = () => {
+    if (this.state.policy.isPaid && !this.state.policy.payer) return false;
     if (!this.state.policy.family) return false;
     if (!this.state.policy.product) return false;
     if (!this.state.policy.enrollDate) return false;

--- a/src/components/PolicyMasterPanel.js
+++ b/src/components/PolicyMasterPanel.js
@@ -428,7 +428,6 @@ class PolicyMasterPanel extends FormPanel {
                     <PublishedComponent
                       pubRef="payer.PayerPicker"
                       withNull={true}
-                      required={edited?.isPaid}
                       readOnly={readOnly}
                       value={edited?.payer}
                       onChange={(p) => this.updateAttribute("payer", p)}

--- a/src/components/PolicyMasterPanel.js
+++ b/src/components/PolicyMasterPanel.js
@@ -426,6 +426,16 @@ class PolicyMasterPanel extends FormPanel {
                   </Grid>
                   <Grid item xs={3} className={classes.item}>
                     <PublishedComponent
+                      pubRef="payer.PayerPicker"
+                      withNull={true}
+                      required={edited?.isPaid}
+                      readOnly={readOnly}
+                      value={edited?.payer}
+                      onChange={(p) => this.updateAttribute("payer", p)}
+                    />
+                  </Grid>
+                  <Grid item xs={3} className={classes.item}>
+                    <PublishedComponent
                       pubRef="core.DatePicker"
                       module="contribution"
                       value={edited?.enrollDate}


### PR DESCRIPTION
[OP-1823](https://openimis.atlassian.net/browse/OP-1823)

BE REQUIRED:
https://github.com/openimis/openimis-be-policy_py/pull/97
https://github.com/openimis/openimis-be-contribution_py/pull/62

Changes:
- Add Payer dropdown when paying in one installment.

[OP-1823]: https://openimis.atlassian.net/browse/OP-1823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ