### PR TITLE
OP-2323: added handling for enquiry policies and eligibility data

### DIFF
--- a/src/components/FamilyOrInsureePoliciesSummary.js
+++ b/src/components/FamilyOrInsureePoliciesSummary.js
@@ -195,6 +195,9 @@ class FamilyOrInsureePoliciesSummary extends PagedDataHandler {
     if (!!this.props.insuree && !!this.props.insuree.chfId) {
       prms.push(`chfId:"${this.props.insuree.chfId}"`);
       return prms;
+    } else if (Boolean(this.props.insureeEnquiry?.chfId)) {
+      prms.push(`chfId:"${this.props.insureeEnquiry?.chfId}"`);
+      return prms;
     } else if (!!this.props.family && !!this.props.family.uuid) {
       prms.push(`familyUuid:"${this.props.family.uuid}"`);
       return prms;
@@ -356,12 +359,17 @@ class FamilyOrInsureePoliciesSummary extends PagedDataHandler {
       errorPolicies,
       family,
       insuree,
+      insureeEnquiry,
       readOnly,
       className,
       hideAddPolicyButton = false,
       disableSelection,
     } = this.props;
-    if ((!family || !family.uuid) && (!insuree || !insuree.uuid)) {
+    if ((!family || !family.uuid) && (!insuree || !insuree.uuid) && (!insureeEnquiry?.uuid))  {
+      console.error(
+        "FamilyOrInsureePoliciesSummary: No valid family, insuree, or insureeEnquiry found. " +
+          "Component will not render."
+      );
       return null;
     }
 
@@ -450,6 +458,7 @@ const mapStateToProps = (state) => ({
   pageInfo: state.policy.policiesPageInfo,
   errorPolicies: state.policy.errorPolicies,
   family: state.insuree.family || {},
+  insureeEnquiry: state?.insuree?.insureeEnquiry,
   insuree: state.insuree.insuree,
   confirmed: state.core.confirmed,
   submittingMutation: state.policy.submittingMutation,

--- a/src/components/FamilyOrInsureePoliciesSummary.js
+++ b/src/components/FamilyOrInsureePoliciesSummary.js
@@ -195,7 +195,7 @@ class FamilyOrInsureePoliciesSummary extends PagedDataHandler {
     if (!!this.props.insuree && !!this.props.insuree.chfId) {
       prms.push(`chfId:"${this.props.insuree.chfId}"`);
       return prms;
-    } else if (Boolean(this.props.insureeEnquiry?.chfId)) {
+    } else if (this.props.insureeEnquiry?.chfId) {
       prms.push(`chfId:"${this.props.insureeEnquiry?.chfId}"`);
       return prms;
     } else if (!!this.props.family && !!this.props.family.uuid) {

--- a/src/components/InsureeEligibilitySummary.js
+++ b/src/components/InsureeEligibilitySummary.js
@@ -69,7 +69,10 @@ class InsureeEligibilitySummary extends Component {
     }
 
     componentDidMount(){
-        this.props?.insuree && this.props.fetchEligibility(this.props.insuree.chfId);
+        const chfId = this.props?.insureeEnquiry?.chfId || this.props?.insuree?.chfId;
+        if (chfId) {
+            this.props.fetchEligibility(chfId);
+        }
     }
 
     componentDidUpdate(prevProps, prevState) {
@@ -79,9 +82,9 @@ class InsureeEligibilitySummary extends Component {
     }
 
     render() {
-        const { classes, insuree, insureeEligibility } = this.props;
-
-        if (!insuree || !insureeEligibility || !this.isEligiblitySummaryEnabled) return null;
+        const { classes, insuree, insureeEnquiry, insureeEligibility } = this.props;
+        const currentInsuree = insureeEnquiry || insuree;
+        if (!currentInsuree || !insureeEligibility || !this.isEligiblitySummaryEnabled) return null;
 
         return (
             <Grid container>
@@ -102,6 +105,7 @@ class InsureeEligibilitySummary extends Component {
 
 const mapStateToProps = state => ({
     insuree: state.insuree.insuree,
+    insureeEnquiry: state?.insuree?.insureeEnquiry,
     fetchingEligibility: state.policy.fetchingInsureeEligibility,
     fetchedEligibility: state.policy.fetchedInsureeEligibility,
     insureeEligibility: state.policy.insureeEligibility,


### PR DESCRIPTION
Ticket:
https://openimis.atlassian.net/browse/OP-2323

Related:
https://github.com/openimis/openimis-fe-insuree_js/pull/154

Changes:
- family or insuree policies summary component takes the insuree enquiry if its available

How was it tested?
1. Local server, enquiry displayed proper data for policies, items and services