### PR TITLE
hide secondaries columns in FamilyOrInsureePoliciesSummary

### DIFF
--- a/src/components/FamilyOrInsureePoliciesSummary.js
+++ b/src/components/FamilyOrInsureePoliciesSummary.js
@@ -237,12 +237,13 @@ class FamilyOrInsureePoliciesSummary extends PagedDataHandler {
       "policies.expiryDate",
       "policies.status",
       "policies.policyValue",
-      !this.hideSecondariesColumns && "policies.deduction",
-      !this.hideSecondariesColumns && "policies.hospitalDeduction",
-      !this.hideSecondariesColumns && "policies.nonHospitalDeduction",
-      !this.hideSecondariesColumns && "policies.ceiling",
-      !this.hideSecondariesColumns && "policies.hospitalCeiling",
-      !this.hideSecondariesColumns && "policies.nonHospitalCeiling",
+      !this.hideSecondariesColumns ? (
+        "policies.deduction", 
+        "policies.hospitalDeduction", 
+        "policies.nonHospitalDeduction", 
+        "policies.ceiling", 
+        "policies.hospitalCeiling", 
+        "policies.nonHospitalCeiling") : null,
     ];
     if (this.showBalance) {
       h.push("policies.balance");

--- a/src/components/FamilyOrInsureePoliciesSummary.js
+++ b/src/components/FamilyOrInsureePoliciesSummary.js
@@ -88,6 +88,11 @@ class FamilyOrInsureePoliciesSummary extends PagedDataHandler {
       "familyOrInsureePoliciesSummary.orderByExpiryDate",
       "expiryDate"
     );
+    this.hideSecondariesColumns = props.modulesManager.getConf(
+      "fe-policy",
+      "familyOrInsureePoliciesSummary.hideSecondariesColumns",
+      true
+    );
   }
 
   componentDidMount() {
@@ -232,12 +237,12 @@ class FamilyOrInsureePoliciesSummary extends PagedDataHandler {
       "policies.expiryDate",
       "policies.status",
       "policies.policyValue",
-      "policies.deduction",
-      "policies.hospitalDeduction",
-      "policies.nonHospitalDeduction",
-      "policies.ceiling",
-      "policies.hospitalCeiling",
-      "policies.nonHospitalCeiling",
+      !this.hideSecondariesColumns && "policies.deduction",
+      !this.hideSecondariesColumns && "policies.hospitalDeduction",
+      !this.hideSecondariesColumns && "policies.nonHospitalDeduction",
+      !this.hideSecondariesColumns && "policies.ceiling",
+      !this.hideSecondariesColumns && "policies.hospitalCeiling",
+      !this.hideSecondariesColumns && "policies.nonHospitalCeiling",
     ];
     if (this.showBalance) {
       h.push("policies.balance");
@@ -291,12 +296,13 @@ class FamilyOrInsureePoliciesSummary extends PagedDataHandler {
       (i) => formatDateFromISO(this.props.modulesManager, this.props.intl, i.expiryDate),
       (i) => formatMessage(this.props.intl, "policy", `policies.status.${i.status}`),
       (i) => <AmountInput value={i.policyValue} readOnly />,
-      (i) => i.ded,
-      (i) => i.dedInPatient,
-      (i) => i.dedOutPatient,
-      (i) => i.ceiling,
-      (i) => i.ceilingInPatient,
-      (i) => i.ceilingOutPatient,
+      !this.hideSecondariesColumns ? (
+        (i) => i.ded,
+        (i) => i.dedInPatient,
+        (i) => i.dedOutPatient,
+        (i) => i.ceiling,
+        (i) => i.ceilingInPatient,
+        (i) => i.ceilingOutPatient) : null,
     ];
     if (this.showBalance) {
       f.push((i) => i.balance);


### PR DESCRIPTION
When opening the page of an insured family, in the contributions panel we find columns with information that is not really necessary in this context. To make the interface clearer and improve user visibility, we have defined a db configuration hideSecondariesColumns in fe-policy module, which is set to true by default to hide these columns.

<img width="1367" height="358" alt="Capture d’écran du 2025-10-02 12-46-45" src="https://github.com/user-attachments/assets/b7718109-2b04-4855-98c6-5b583aa02bd7" />
<img width="1831" height="367" alt="Capture d’écran du 2025-10-09 14-59-31" src="https://github.com/user-attachments/assets/83847793-ff9b-4572-b100-8c99458156d7" />
