### PR TITLE
hide renew button for policies that have null value OP-2797

### DIFF
--- a/src/components/FamilyOrInsureePoliciesSummary.js
+++ b/src/components/FamilyOrInsureePoliciesSummary.js
@@ -280,7 +280,7 @@ class FamilyOrInsureePoliciesSummary extends PagedDataHandler {
   rowLocked = (policy) => !!policy.clientMutationId;
   canDelete = (policy) => !this.props.readOnly && canDeletePolicy(this.props.rights, policy);
   canSuspend = (policy) => !this.props.readOnly && canSuspendPolicy(this.props.rights, policy);
-  canRenew = (policy) => !this.props.readOnly && canRenewPolicy(this.props.rights, policy);
+  canRenew = (policy) => !this.props.readOnly && canRenewPolicy(this.props.rights, policy) && policy.policyValue != null
 
   itemFormatters = () => {
     let f = [

--- a/src/components/PolicySearcher.js
+++ b/src/components/PolicySearcher.js
@@ -151,7 +151,7 @@ class PolicySearcher extends Component {
 
     canDelete = (policy) => canDeletePolicy(this.props.rights, policy)
     canSuspend = (policy) => canSuspendPolicy(this.props.rights, policy)
-    canRenew = (policy) => !this.props.renew && canRenewPolicy(this.props.rights, policy)
+    canRenew = (policy) => !this.props.renew && canRenewPolicy(this.props.rights, policy) && policy.value != null
 
     headers = (filters) => {
         const h = [


### PR DESCRIPTION
We observed in the release data that it is impossible to renew a policy with a `policyValue` that is null, so we proposed hiding the renew button for policies with `policyValue == null`.