### PR TITLE
Fix syntax error in FamilyOrInsureePoliciesSummary.js

### DIFF
--- a/src/components/FamilyOrInsureePoliciesSummary.js
+++ b/src/components/FamilyOrInsureePoliciesSummary.js
@@ -263,7 +263,7 @@ class FamilyOrInsureePoliciesSummary extends PagedDataHandler {
         "policies.hospitalCeiling",
         "policies.nonHospitalCeiling",
         ...(this.showBalance ? ["policies.balance"] : [])
-      ])
+      ]),
       "policies.policyValue",
       !this.hideSecondariesColumns ? (
         "policies.deduction", 


### PR DESCRIPTION
# Description

Fixes syntax error in react component causing builds to fail.

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

Upload screenshots/gifs or link to any demo video here.

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
