### PR TITLE
fix: OP-3089 Fix theme.spacing crash in PolicyDetailsCollapse

### DIFF
--- a/src/components/PolicyDetailsCollapse.jsx
+++ b/src/components/PolicyDetailsCollapse.jsx
@@ -1,17 +1,6 @@
 import React from "react";
-import { withStyles } from "@material-ui/core/styles";
-import { Collapse, Paper } from "@material-ui/core";
+import { Collapse, Paper } from "@mui/material";
 import { withModulesManager, formatMessage, Table } from "@openimis/fe-core";
-
-const styles = (theme) => ({
-  root: {
-    marginTop: theme.spacing(1),
-    marginBottom: theme.spacing(1),
-  },
-  tableContainer: {
-    margin: theme.spacing(1),
-  },
-});
 
 class PolicyDetailsCollapse extends React.Component {
   getHeaders = () => {
@@ -46,13 +35,13 @@ class PolicyDetailsCollapse extends React.Component {
   };
 
   render() {
-    const { classes, open, policy, intl } = this.props;
+    const { open, policy, intl } = this.props;
     
     if (!policy) return null;
 
     return (
-      <Collapse in={open} timeout="auto" unmountOnExit className={classes.root}>
-        <Paper className={classes.tableContainer} elevation={1}>
+      <Collapse in={open} timeout="auto" unmountOnExit sx={{ mt: 1, mb: 1 }}>
+        <Paper sx={{ m: 1 }} elevation={1}>
           <Table
             module="policy"
             headers={this.getHeaders()}
@@ -67,4 +56,4 @@ class PolicyDetailsCollapse extends React.Component {
   }
 }
 
-export default withModulesManager(withStyles(styles)(PolicyDetailsCollapse));
+export default withModulesManager(PolicyDetailsCollapse);


### PR DESCRIPTION
#Thank you for your contribution to openIMIS!
#Please complete the sections below. Anything in comments is guidance and can be deleted.

# Description

A clear, concise description of the change. Why is it needed? What problem does it solve?

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

<img width="1599" height="910" alt="Pasted Graphic 5" src="https://github.com/user-attachments/assets/8475f406-0d2a-4c96-961c-317bdc6dc948" />

Fix:
<img width="1599" height="910" alt="image" src="https://github.com/user-attachments/assets/4cf456d9-6aa5-4282-9a7c-59c163bf0fbd" />


## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
