### PR TITLE
fix one policy selection

### DIFF
--- a/src/components/FamilyOrInsureePoliciesSummary.jsx
+++ b/src/components/FamilyOrInsureePoliciesSummary.jsx
@@ -497,6 +497,7 @@ class FamilyOrInsureePoliciesSummary extends PagedDataHandler {
           headers={this.headers()}
           headerActions={this.headerActions()}
           items={policies}
+          itemIdentifier={this.itemIdentifier}
           fetching={fetchingPolicies}
           itemFormatters={this.itemFormatters()}
           error={errorPolicies}


### PR DESCRIPTION
# Description

In the family policy list, selecting one policy automatically selects all the other policies as well. i added itemIdentifier in table props to fix that

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo


https://github.com/user-attachments/assets/de1d1d5f-531b-4a09-b3b6-dfb4306321d0



## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
