### PR TITLE
hide actions in searcher

### DIFF
--- a/src/components/PolicySearcher.jsx
+++ b/src/components/PolicySearcher.jsx
@@ -306,11 +306,10 @@ class PolicySearcher extends Component {
             )
         : null,
       (policy) => {
-        if (!policy.family) return null;
         return (
           <ActionMenu
             actions={[
-              {
+              !!policy.family && {
                 icon: <PeopleIcon />,
                 tooltip: formatMessage(
                 this.props.intl,

--- a/src/components/PolicySearcher.jsx
+++ b/src/components/PolicySearcher.jsx
@@ -2,12 +2,6 @@ import React, { Component, Fragment } from "react";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import { injectIntl } from "react-intl";
-import { GetIconComponent, ActionMenu } from "@openimis/fe-core";
-const PeopleIcon = GetIconComponent("People")
-const TabIcon = GetIconComponent("Tab")
-const RenewIcon = GetIconComponent("Autorenew")
-const DeleteIcon = GetIconComponent("Delete")
-const SuspendIcon = GetIconComponent("Pause")
 
 import {
   withModulesManager,
@@ -22,6 +16,8 @@ import {
   Searcher,
   PublishedComponent,
   AmountInput,
+  GetIconComponent,
+  ActionMenu,
 } from "@openimis/fe-core";
 import { fetchPolicySummaries, deletePolicy, suspendPolicy } from "../actions";
 import {
@@ -31,6 +27,11 @@ import {
   canSuspendPolicy,
   canRenewPolicy,
 } from "../utils/utils";
+const PeopleIcon = GetIconComponent("People")
+const TabIcon = GetIconComponent("Tab")
+const RenewIcon = GetIconComponent("Autorenew")
+const DeleteIcon = GetIconComponent("Delete")
+const SuspendIcon = GetIconComponent("Pause")
 
 import PolicyFilter from "./PolicyFilter";
 

--- a/src/components/PolicySearcher.jsx
+++ b/src/components/PolicySearcher.jsx
@@ -2,8 +2,7 @@ import React, { Component, Fragment } from "react";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import { injectIntl } from "react-intl";
-import { Button, Tooltip } from "@mui/material";
-import { GetIconComponent } from "@openimis/fe-core";
+import { GetIconComponent, ActionMenu } from "@openimis/fe-core";
 const PeopleIcon = GetIconComponent("People")
 const TabIcon = GetIconComponent("Tab")
 const RenewIcon = GetIconComponent("Autorenew")
@@ -308,125 +307,90 @@ class PolicySearcher extends Component {
       (policy) => {
         if (!policy.family) return null;
         return (
-          <Tooltip
-            title={formatMessage(
-              this.props.intl,
-              "policy",
-              "policySummaries.openFamilyButton.tooltip"
-            )}
-          >
-            <Button
-              startIcon={<PeopleIcon />}
-              onClick={(e) =>
-                !policy.clientMutationId &&
-                historyPush(
-                  this.props.modulesManager,
-                  this.props.history,
-                  "insuree.route.familyOverview",
-                  [policy.family.uuid]
+          <ActionMenu
+            actions={[
+              {
+                icon: <PeopleIcon />,
+                tooltip: formatMessage(
+                this.props.intl,
+                "policy",
+                "policySummaries.openFamilyButton.tooltip",
+                ),
+                label: formatMessage(
+                  this.props.intl,
+                  "policy",
+                  "policySummaries.openFamilyButton.buttonText"
+                ),
+                action: () =>
+                  !policy.clientMutationId &&
+                  historyPush(
+                    this.props.modulesManager,
+                    this.props.history,
+                    "insuree.route.familyOverview",
+                    [policy.family.uuid]
+                  )
+              },
+              {
+                icon: <TabIcon />,
+                tooltip: formatMessage(
+                  this.props.intl,
+                  "policy",
+                  "policySummaries.openNewTabButton.tooltip"
+                ),
+                action: () => !policy.clientMutationId && this.props.onDoubleClick(policy, true),
+                label: formatMessage(
+                  this.props.intl,
+                  "policy",
+                  "policySummaries.openNewTabButton.buttonText"
+                )
+              },
+              this.canRenew(policy) && {
+                icon: <RenewIcon />,
+                tooltip: formatMessage(
+                  this.props.intl,
+                  "policy",
+                  "action.RenewPolicy.tooltip"
+                ),
+                label: formatMessage(
+                  this.props.intl,
+                  "policy",
+                  "action.RenewPolicy.buttonText"
+                ),
+                action: () => !policy.clientMutationId && this.renewPolicy(policy)
+              },
+              this.canSuspend(policy) && {
+                tooltip: formatMessage(
+                  this.props.intl,
+                  "policy",
+                  "action.SuspendPolicy.tooltip"
+                ),
+                icon: <SuspendIcon />,
+                action: () => !policy.clientMutationId && this.confirmSuspend(policy),
+                label: formatMessage(
+                  this.props.intl,
+                  "policy",
+                  "action.SuspendPolicy.buttonText"
+                )
+              },
+              this.canDelete(policy) && {
+                divider: true,
+                icon: <DeleteIcon />,
+                label: formatMessage(
+                  this.props.intl,
+                  "policy",
+                  "action.DeletePolicy.buttonText"
+                ),
+                action: () => !policy.clientMutationId && this.confirmDelete(policy),
+                tooltip: formatMessage(
+                  this.props.intl,
+                  "policy",
+                  "action.DeletePolicy.tooltip"
                 )
               }
-            >
-              {formatMessage(
-                this.props.intl,
-                "policy",
-                "policySummaries.openFamilyButton.buttonText"
-              )}
-            </Button>
-          </Tooltip>
+            ].filter(Boolean)}
+          />
         );
       },
-      (policy) => (
-        <Tooltip
-          title={formatMessage(
-            this.props.intl,
-            "policy",
-            "policySummaries.openNewTabButton.tooltip"
-          )}
-        >
-          <Button
-            startIcon={<TabIcon />}
-            onClick={(e) =>
-              !policy.clientMutationId && this.props.onDoubleClick(policy, true)
-            }
-          >
-            {formatMessage(
-              this.props.intl,
-              "policy",
-              "policySummaries.openNewTabButton.buttonText"
-            )}
-          </Button>
-        </Tooltip>
-      ),
-      (policy) =>
-        this.canRenew(policy) && (
-          <Tooltip
-            title={formatMessage(
-              this.props.intl,
-              "policy",
-              "action.RenewPolicy.tooltip"
-            )}
-          >
-            <Button
-              startIcon={<RenewIcon />}
-              onClick={(e) =>
-                !policy.clientMutationId && this.renewPolicy(policy)
-              }
-            >
-              {formatMessage(
-                this.props.intl,
-                "policy",
-                "action.RenewPolicy.buttonText"
-              )}
-            </Button>
-          </Tooltip>
-        ),
-      (policy) =>
-        this.canSuspend(policy) && (
-          <Tooltip
-            title={formatMessage(
-              this.props.intl,
-              "policy",
-              "action.SuspendPolicy.tooltip"
-            )}
-          >
-            <Button
-              startIcon={<SuspendIcon />}
-              onClick={(e) =>
-                !policy.clientMutationId && this.confirmSuspend(policy)
-              }
-            >
-              {formatMessage(
-                this.props.intl,
-                "policy",
-                "action.SuspendPolicy.buttonText"
-              )}
-            </Button>
-          </Tooltip>
-        ),
-      (policy) =>
-        this.canDelete(policy) && (
-          <Tooltip
-            title={formatMessage(
-              this.props.intl,
-              "policy",
-              "action.DeletePolicy.tooltip"
-            )}
-          >
-            <Button
-              startIcon={<DeleteIcon />}
-              onClick={(e) =>
-                !policy.clientMutationId && this.confirmDelete(policy)
-              }
-            >
-              {formatMessage(
-                this.props.intl,
-                "policy",
-                "action.DeletePolicy.buttonText"
-              )}
-            </Button>
-          </Tooltip>
-        ),
     ];
     return formatters;
   };


### PR DESCRIPTION
# Description

Hide the action buttons in the list to free up space and improve the table layout

# Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [x] Requires [https://github.com/openimis/openimis-fe-core_js/pull/342], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

<img width="1362" height="536" alt="Screenshot 2026-08-03 at 9 55 13 AM" src="https://github.com/user-attachments/assets/e4e4da28-4fb1-4515-a383-11edaf2739e0" />

<img width="1347" height="407" alt="Screenshot 2026-08-03 at 11 41 42 AM" src="https://github.com/user-attachments/assets/4bbf49e9-1f9a-46e0-b62d-828026042adb" />


## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
